### PR TITLE
Add option to read reference sequence into memory

### DIFF
--- a/GencallGenerator.py
+++ b/GencallGenerator.py
@@ -48,7 +48,7 @@ class GencallGenerator(object):
         Args:
             bpm_records (iter(BPMRecord)) : BPM records
             vcf_record (vcf._Record): VCF record
-            sample_namem (string): Name of sample
+            sample_name (string): Name of sample
 
         Returns:
             float: Minimum GenCall score (or None for empty arguments)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ usage: gtc_to_vcf.py [-h] [--gtc-file GTC_FILE] --manifest-file MANIFEST_FILE
                      [--output-vcf-file OUTPUT_VCF_FILE] [--skip-indels]
                      [--log-file LOG_FILE] [--expand-identifiers]
                      [--unsquash-duplicates] [--auxiliary-loci AUXILIARY_LOCI]
+                     [--filter-loci FILTER_LOCI] [--disable-genome-cache]
                      [--version]
 
 Convert GTC file to VCF format
@@ -31,7 +32,10 @@ optional arguments:
   --filter-loci FILTER_LOCI
                         File containing list of loci names to filter from
                         input manifest
+  --disable-genome-cache
+                        Disable caching of genome reference data
   --version             show program's version number and exit
+
 ```
 ## Input details
 ### Manifests
@@ -47,6 +51,9 @@ The contig identifiers in the provided genome FASTA file must match exactly the 
 
 ### Squashing duplicates
 In the manifest, there can be cases where the same variant is probed by multiple different assays. These assays may be the same design or alternate designs for the same locus. In the default mode of operation, these duplicates will be "squashed" into a single record in the VCF. The method used to incorporate information across multiple assays is under the latter "Output description" heading. When the "--unsquash-duplicates" option is provided, this "squashing" behavior is disabled, and each duplicate assay will be reported in a separate entry in the VCF file. This option is helpful when you are interested in investigating or validating the performance of individual assays, rather than trying to generate genotypes for specific variants. Note that if an locus has more than two alleles and is also queried with duplicated designs, the duplicates will not be unsquashed. 
+
+### Genome cache
+By default, the entire reference genome will be read into memory. Generally, this will be more efficient than reading data from the indexed reference on disk at the expense of greater memory utilization. For situations in which the genome caching is not desirable (low memory availability or a small input manifest), it is possible to disable this default behavior with the "--disable-genome-cache" option. 
 
 ### Auxiliary loci
 Certain classes of variant types (such as multi-nucleotide variants) are not currently supported in the upstream analysis software that produces GTC files. However, it is possible to query this type of variant by creating a SNP design that differentiates the specific multi-nucleotide alleles of interest. For example, if the true source sequence is

--- a/ReaderTemplateFactory.py
+++ b/ReaderTemplateFactory.py
@@ -3,7 +3,6 @@ from tempfile import mkstemp
 from collections import OrderedDict
 from vcf.parser import Reader, _Contig
 
-
 class ReaderTemplateFactory(object):
     """Class to create new reader templates"""
 
@@ -91,7 +90,7 @@ class ReaderTemplateFactory(object):
             dict(string,_Contig): Contig information
         """
         contigs = {}
-        for contig_name, length in zip(self._genome_reader.fasta_file.references, self._genome_reader.fasta_file.lengths):
+        for contig_name, length in self._genome_reader.get_contig_lengths():
             if contig_name.isdigit():
                 contigs[int(contig_name)] = _Contig(contig_name, length)
             else:

--- a/ReferenceGenome.py
+++ b/ReferenceGenome.py
@@ -24,15 +24,15 @@ class ReferenceGenome(object):
         """
         self._logger = logger
         self.genome_fasta_file = genome_fasta_file
-        self._validate_reference_file(genome_fasta_file)
+        self._validate_reference_file()
 
         try:
-            self.fasta_file = Fastafile(self.genome_fasta_file)
+            self._fasta_file = Fastafile(self.genome_fasta_file)
         except:
             raise IOError("Could not read genome file: " +
                           self.genome_fasta_file)
 
-    def _validate_reference_file(self, genome_fasta_file):
+    def _validate_reference_file(self):
         """
         Check whether reference file is valid
 
@@ -45,6 +45,18 @@ class ReferenceGenome(object):
         if not os.path.isfile(self.genome_fasta_file + ".fai"):
             raise ValueError(
                 "Supplied genome FASTA file does not have FASTA index")
+
+    def get_contig_lengths(self):
+        """
+        Get the names and lengths of all contigs in a references
+
+        Args:
+            None
+
+        Returns:
+            list(tuple(string,int)): Returns a list representing the name and lengths of all contigs in reference
+        """
+        return zip(self._fasta_file.references, self._fasta_file.lengths)
 
     def get_reference_bases(self, chrom, start, end):
         """
@@ -61,13 +73,80 @@ class ReferenceGenome(object):
         Raises:
             ValueError - Invalid arguments
         """
-
         if start >= end:
             raise ValueError("Start/stop coordinates incorrect for: " +
                              str(chrom) + ":" + str(start) + "-" + str(end))
 
-        if chrom not in self.fasta_file:
+        if chrom not in self._fasta_file:
             raise ValueError(
                 "FASTA reference is missing entry for chromosome " + str(chrom))
 
-        return self.fasta_file.fetch(str(chrom), start, end)
+        return self._fasta_file.fetch(str(chrom), start, end)
+
+class CachedReferenceGenome(object):
+    """
+    Class to provide sequence data from a reference genome. All sequence
+    data will be cached into memory.
+
+    Attributes:
+        genome_fasta_file (string): Path to reference genome file
+    """
+    def __init__(self, reference_genome, logger): 
+        self._logger = logger
+        self._logger.info("Caching reference data")
+        self._cache = CachedReferenceGenome.generate_genome_cache(reference_genome)
+        self._logger.info("Finished caching reference data")
+        self.genome_fasta_file = reference_genome.genome_fasta_file
+
+    @staticmethod
+    def generate_genome_cache(reference_genome):
+        """
+        Get the reference bases from start to end
+
+        Args:
+            reference_genome (ReferenceGenome): A reference genome that provides the information to be cached
+
+        Returns:
+            dict(string,string): A dictionary that maps from contig name to bases for that contig
+        """        
+        result = {}
+        for (contig, contig_length) in reference_genome.get_contig_lengths():
+            result[contig] = reference_genome.get_reference_bases(contig, 0, contig_length)
+        return result 
+
+    def get_contig_lengths(self):
+        """
+        Get the names and lengths of all contigs in a references
+
+        Args:
+            None
+
+        Returns:
+            list(tuple(string,int)): Returns a list representing the name and lengths of all contigs in reference
+        """
+        return [(contig, len(self._cache[contig])) for contig in self._cache]
+
+    def get_reference_bases(self, chrom, start, end):
+        """
+        Get the reference bases from start to end
+
+        Args:
+            chrom (string): Chromsome to query
+            start (int): Start position to query
+            end (int): End position (not inclusive)
+
+        Returns:
+            string: The genome sequence
+
+        Raises:
+            ValueError - Invalid arguments
+        """
+        if start >= end:
+            raise ValueError("Start/stop coordinates incorrect for: " +
+                             str(chrom) + ":" + str(start) + "-" + str(end))
+
+        if chrom not in self._cache:
+            raise ValueError(
+                "Reference is missing entry for chromosome " + str(chrom))
+
+        return self._cache[str(chrom)][start:end]


### PR DESCRIPTION
Update to improve performance by reading all reference sequence information into memory. Analysis time reduced from 19 minutes to 11 minutes for Omni5M test data. Result VCF is identical to 1.0.1 release. 