### PR TITLE
Possible error in comment on last test

### DIFF
--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -205,9 +205,9 @@ class TestCombinedGenotypes(unittest.TestCase):
         data.append((BPMRecord("", None, None, "", 0, "[T/G]", RefStrand.Plus, 1, None, None, None, None, 1, logger), 2))
         self.check_genotype(data, ('T', 'G'))
 
-        # Inf II [A/G] -> AG
-        # Inf I [T/G] -> TG
-        # TG
+        # Inf II [A/G] -> AA
+        # Inf I [T/G] -> TT
+        # --
         data = []
         data.append((BPMRecord("", None, None, "", 0, "[A/G]", RefStrand.Plus, 0, None, None, None, None, 1, logger), 1))
         data.append((BPMRecord("", None, None, "", 0, "[T/G]", RefStrand.Plus, 1, None, None, None, None, 1, logger), 1))


### PR DESCRIPTION
The comment on the last test did not seem to coincide with what was being actually tested, and looked more like a copy of the comment on the previous test. I corrected it taking as an example the fourth to last test.