### PR TITLE
Update download_reference.sh

### DIFF
--- a/scripts/download_reference.sh
+++ b/scripts/download_reference.sh
@@ -6,7 +6,7 @@ then
     exit 1
 fi
 
-output_file=`realpath ${1}`
+output_file=`readlink -f ${1}`
 output_dir=`dirname ${output_file}`
 genome_build=${2:-"37"}
 


### PR DESCRIPTION
Convert `realpath` to `readlink -f`, which might be more generally supported on UNIX.
Closes #35 