### PR TITLE
Now supports extracting gencall scores (GCALL) as real numbers

### DIFF
--- a/FormatFactory.py
+++ b/FormatFactory.py
@@ -1,5 +1,6 @@
 from GenotypeFormat import GenotypeFormat
 from GencallFormat import GencallFormat
+from GencallFormatReal import GencallFormatReal
 from BAlleleFreqFormat import BAlleleFreqFormat
 from LogRRatioFormat import LogRRatioFormat
 
@@ -31,6 +32,8 @@ class FormatFactory(object):
                 self._format_classes.append(GenotypeFormat)
             if GencallFormat.get_id() in formats_to_include:
                 self._format_classes.append(GencallFormat)
+            if GencallFormatReal.get_id() in formats_to_include:
+                self._format_classes.append(GencallFormatReal)
             if BAlleleFreqFormat.get_id() in formats_to_include:
                 self._format_classes.append(BAlleleFreqFormat)
             if LogRRatioFormat.get_id() in formats_to_include:
@@ -40,6 +43,7 @@ class FormatFactory(object):
     def get_possible_formats():
         valid_classes = [GenotypeFormat.get_id(),
                          GencallFormat.get_id(),
+                         GencallFormatReal.get_id(),
                          BAlleleFreqFormat.get_id(),
                          LogRRatioFormat.get_id()]
         return valid_classes
@@ -97,6 +101,9 @@ class FormatFactory(object):
                 self._logger, gtc.get_gender(), gtc.get_genotypes()))
         if GencallFormat.get_id() in self._formats_to_include:
             result.append(GencallFormat(
+                self._logger, gtc.get_genotype_scores()))
+        if GencallFormatReal.get_id() in self._formats_to_include:
+            result.append(GencallFormatReal(
                 self._logger, gtc.get_genotype_scores()))
         if BAlleleFreqFormat.get_id() in self._formats_to_include:
             result.append(BAlleleFreqFormat(

--- a/GencallFormatReal.py
+++ b/GencallFormatReal.py
@@ -1,0 +1,64 @@
+from vcf.parser import _Format
+
+# Edited by August Woerner; borrowed (heavily) from GencallFormat.py
+
+class GencallFormatReal(object):
+    """
+    Generate GQ format information for VCF
+    """
+
+    def __init__(self, logger, gencall_scores):
+        """
+        Create new GencallFormatReal object
+
+        Args:
+            logger (logging.Logger): Logging object for errors/warnings
+            gencall_scores (list(float)): List of all gencall scores for all loci across sample
+
+        Returns
+            GencallFormatReal
+        """
+        self._logger = logger
+        self._gencall_scores = gencall_scores
+
+    @staticmethod
+    def get_id():
+        return "GCALL"
+
+    @staticmethod
+    def get_description():
+        return "GenCall score as a real number. For merged multi-locus entries, max(GenCall) score is reported."
+
+    @staticmethod
+    def get_format_obj():
+        return _Format(
+            GencallFormatReal.get_id(), 1, "Float", GencallFormatReal.get_description())
+
+    def _get_max_gencall_score(self, bpm_records):
+        """
+        Look up gencall scores for entries defined by bpm_records and report
+        the minimum.
+
+        Args:
+            bpm_records iter(BPMRecord) : Iterable of BPM records
+
+        Returns
+            float : MAX gen call score
+        """
+        return max(self._gencall_scores[record.index_num] for record in bpm_records)
+
+    def generate_sample_format_info(self, bpm_records, vcf_record, sample_name):
+        """
+        Returns sample format info (GQ score)
+
+        Args:
+            bpm_records (iter(BPMRecord)) : BPM records
+            vcf_record (vcf._Record): VCF record
+            sample_name (string): Name of sample
+
+        Returns:
+            float: MAX GenCall score, as a real number [0,1].
+        """
+        gencall_score = self._get_max_gencall_score(bpm_records)
+        #phred_quality_score = int(round(-10*log10(min(1.0, max(0.00001, 1 - min_gencall_score)))))
+        return gencall_score


### PR DESCRIPTION
I added support for exporting an extra field; the GenCall score (without Phred scaling, so as to have better precision).
(And I use git forking mechanics once in a blue moon, so apologies in advance!)

While this is not the place, it would also be handy to export the gentrain score too, but I could not find programmatic access to it.

Thanks!
-August
